### PR TITLE
ESM module import compatibility 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 
-import Phaser from 'phaser';
+import * as Phaser from 'phaser';
 import { PhaserGame } from './PhaserGame';
 
 function App ()

--- a/src/game/EventBus.js
+++ b/src/game/EventBus.js
@@ -1,4 +1,4 @@
-import Phaser from 'phaser';
+import * as Phaser from 'phaser';
 
 // Used to emit events between components, HTML and Phaser scenes
 export const EventBus = new Phaser.Events.EventEmitter();

--- a/src/game/main.js
+++ b/src/game/main.js
@@ -2,7 +2,7 @@ import { Boot } from './scenes/Boot';
 import { Game } from './scenes/Game';
 import { GameOver } from './scenes/GameOver';
 import { MainMenu } from './scenes/MainMenu';
-import Phaser from 'phaser';
+import * as Phaser from 'phaser';
 import { Preloader } from './scenes/Preloader';
 
 // Find out more information about the Game Config at:


### PR DESCRIPTION
When attempting to launch the project following the documentation, "import Phaser" was not working due to ESM/CommonJS module import mismatches.

Simple update of these import statements to use "import * as Phaser" so that the code runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk import-only change; main risk is if some tooling relied on the default Phaser export, but usage remains unchanged via the `Phaser` namespace.
> 
> **Overview**
> Fixes Phaser ESM/CommonJS interop issues by switching `import Phaser from 'phaser'` to `import * as Phaser from 'phaser'` in the React app (`App.jsx`), shared `EventBus`, and game bootstrap (`main.js`), keeping all existing `Phaser.*` usages intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dfb9097a25000bb588bcad20fc7a4f4980e5844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->